### PR TITLE
fix unable to insert image in wysiwyg when post is new

### DIFF
--- a/src/app/design/adminhtml/default/default/layout/fontis/blog.xml
+++ b/src/app/design/adminhtml/default/default/layout/fontis/blog.xml
@@ -27,6 +27,9 @@
             <block type="blog/manage_blog" name="blog" template="fontis/blog/posts.phtml" />
         </reference>
     </adminhtml_blog_blog_index>
+    <adminhtml_blog_blog_new>
+        <update handle="editor"/>
+    </adminhtml_blog_blog_new>
     <adminhtml_blog_blog_edit>
         <update handle="editor"/>
     </adminhtml_blog_blog_edit>


### PR DESCRIPTION
Currently insert image through wysiwyg doesn't work if the blog post hasn't been saved once. So, this fix will solve the issue. I hope it's accepted to be merged, so everyone can take benefit of it.
